### PR TITLE
Depend on `ghc-prim` only for GHC 7.2/7.4

### DIFF
--- a/cassava.cabal
+++ b/cassava.cabal
@@ -49,7 +49,10 @@ Library
 
   if impl(ghc >= 7.2.1)
     cpp-options: -DGENERICS
-    build-depends: ghc-prim >= 0.2 && < 0.4
+
+    -- GHC.Generics lived in `ghc-prim` for GHC 7.2 & GHC 7.4 only
+    if impl(ghc < 7.6)
+      build-depends: ghc-prim == 0.2.*
 
 Test-suite unit-tests
   Type: exitcode-stdio-1.0
@@ -106,7 +109,10 @@ Benchmark benchmarks
 
   if impl(ghc >= 7.2.1)
     cpp-options: -DGENERICS
-    build-depends: ghc-prim >= 0.2 && < 0.4
+
+    -- GHC.Generics lived in `ghc-prim` for GHC 7.2 & GHC 7.4 only
+    if impl(ghc < 7.6)
+      build-depends: ghc-prim == 0.2.*
 
   -- We cannot depend on the library directly as that creates a
   -- dependency cycle.


### PR DESCRIPTION
`cassava` only needs `ghc-prim` since `GHC.Generics` used to live in
`ghc-prim`, but only for GHC 7.2 & GHC 7.4