### PR TITLE
Bump upper bounds for attoparsec

### DIFF
--- a/cassava.cabal
+++ b/cassava.cabal
@@ -92,7 +92,7 @@ Benchmark benchmarks
 
   Build-depends:
     array < 0.6,
-    attoparsec >= 0.10.2 && < 0.13,
+    attoparsec >= 0.10.2 && < 0.14,
     base >= 4.5 && < 5,
     blaze-builder < 0.5,
     bytestring < 0.11,


### PR DESCRIPTION
Bump upper bounds for attoparsec in benchmark section to match the rest of the attoparsec deps. This is needed for https://github.com/fpco/stackage/issues/572