### PR TITLE
OverlappingInstances are deprecated in GHC 7.10.

### DIFF
--- a/Data/Csv/Conversion.hs
+++ b/Data/Csv/Conversion.hs
@@ -492,7 +492,7 @@ class ToField a where
     toField :: a -> Field
 
 -- | 'Nothing' if the 'Field' is 'B.empty', 'Just' otherwise.
-instance FromField a => FromField (Maybe a) where
+instance {-# OVERLAPPABLE #-} FromField a => FromField (Maybe a) where
     parseField s
         | B.null s  = pure Nothing
         | otherwise = Just <$> parseField s

--- a/Data/Csv/Conversion.hs
+++ b/Data/Csv/Conversion.hs
@@ -6,13 +6,16 @@
     FlexibleInstances,
     KindSignatures,
     MultiParamTypeClasses,
-    OverlappingInstances,
     OverloadedStrings,
     Rank2Types,
     ScopedTypeVariables,
     TypeOperators,
     UndecidableInstances
     #-}
+#if __GLASGOW_HASKELL__ < 710
+{-# LANGUAGE OverlappingInstances #-}
+#endif
+
 module Data.Csv.Conversion
     (
     -- * Type conversion

--- a/Data/Csv/Conversion.hs
+++ b/Data/Csv/Conversion.hs
@@ -492,7 +492,11 @@ class ToField a where
     toField :: a -> Field
 
 -- | 'Nothing' if the 'Field' is 'B.empty', 'Just' otherwise.
-instance {-# OVERLAPPABLE #-} FromField a => FromField (Maybe a) where
+instance
+#if __GLASGOW_HASKELL__ >= 710
+  {-# OVERLAPPABLE #-}
+#endif
+  FromField a => FromField (Maybe a) where
     parseField s
         | B.null s  = pure Nothing
         | otherwise = Just <$> parseField s


### PR DESCRIPTION
You may still need to add `OVERLAPPING` pragmas to some instances. GHC doesn't report overlapping instances at the definition site, and I couldn't find them just by reading the code. Tests and benchmarks still compile, though.